### PR TITLE
Dev.temp files on windows using PortableNamedTemporaryFile

### DIFF
--- a/readalongs/align.py
+++ b/readalongs/align.py
@@ -9,7 +9,7 @@
 #
 #######################################################################
 
-from tempfile import NamedTemporaryFile
+from readalongs.tempfile import PortableNamedTemporaryFile
 from datetime import timedelta
 from typing import List, Union
 import wave
@@ -115,14 +115,14 @@ def align_audio(xml_path: str, wav_path: str, unit:str ='w', bare=False, save_te
     if save_temps:
         dict_file = io.open(save_temps + '.dict', 'wb')
     else:
-        dict_file = NamedTemporaryFile(prefix='readalongs_dict_', delete=False)
+        dict_file = PortableNamedTemporaryFile(prefix='readalongs_dict_', delete=False)
     dict_file.write(dict_data.encode('utf-8'))
     dict_file.flush()
     fsg_data = make_fsg(xml, xml_path, unit=unit)
     if save_temps:
         fsg_file = io.open(save_temps + '.fsg', 'wb')
     else:
-        fsg_file = NamedTemporaryFile(prefix='readalongs_fsg_', delete=False)
+        fsg_file = PortableNamedTemporaryFile(prefix='readalongs_fsg_', delete=False)
     fsg_file.write(fsg_data.encode('utf-8'))
     fsg_file.flush()
 
@@ -460,8 +460,8 @@ def create_input_xml(inputfile: str, text_language: Union[str, None] = None, sav
         filename = save_temps + '.input.xml'
         outfile = io.open(filename, 'wb')
     else:
-        outfile = NamedTemporaryFile(prefix='readalongs_xml_',
-                                     suffix='.xml')
+        outfile = PortableNamedTemporaryFile(prefix='readalongs_xml_',
+                                     suffix='.xml', delete=True)
         filename = outfile.name
     with io.open(inputfile, encoding="utf-8") as fin:
         text = []
@@ -485,6 +485,7 @@ def create_input_xml(inputfile: str, text_language: Union[str, None] = None, sav
                               {'sentences': sentences})
         outfile.write(xml.encode('utf-8'))
         outfile.flush()
+        outfile.close()
     return outfile, filename
 
 def create_input_tei(text: str, **kwargs):
@@ -515,8 +516,8 @@ def create_input_tei(text: str, **kwargs):
         filename = save_temps + '.input.xml'
         outfile = io.open(filename, 'wb')
     else:
-        outfile = NamedTemporaryFile(prefix='readalongs_xml_',
-                                     suffix='.xml')
+        outfile = PortableNamedTemporaryFile(prefix='readalongs_xml_',
+                                     suffix='.xml', delete=True)
         filename = outfile.name
     pages = []
     paragraphs = []
@@ -542,4 +543,5 @@ def create_input_tei(text: str, **kwargs):
     xml = pystache.render(TEI_TEMPLATE, {**kwargs, **{'pages': pages}})
     outfile.write(xml.encode('utf-8'))
     outfile.flush()
+    outfile.close()
     return outfile, filename

--- a/readalongs/tempfile.py
+++ b/readalongs/tempfile.py
@@ -1,0 +1,69 @@
+"""
+Wrapper to make tempfile.NamedTemporaryFile work as we need it to on Windows and *nix.
+Desired behaviour: with delete=True, we want to be able to write to the file, and open it again
+with a different file handle for reading. On Linux, closing the file deletes it right away,
+while on Windows, you cannot reopen the file unless you've closed it first.
+So this wrapper deletes the file on exit or object deletion instead of closing.
+"""
+
+from readalongs.log import LOGGER
+from tempfile import NamedTemporaryFile, template, _TemporaryFileWrapper
+import os
+
+class _PortableNamedTemporaryFileWrapperSubclass(_TemporaryFileWrapper):
+    def __init__(self):
+        pass
+
+class _PortableNamedTemporaryFileWrapper:
+    def __init__(self, named_temporary_file):
+        self.named_temporary_file = named_temporary_file
+        self.name = named_temporary_file.name
+        #LOGGER.info("_PortableNamedTemporaryFileWrapper.name={}".format(self.name))
+
+
+    def __enter__(self):
+        self.named_temporary_file.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        result = self.named_temporary_file.__exit__(exc_type, exc_value, traceback)
+        self.cleanup()
+        return result
+
+    def __del__(self):
+        self.cleanup()
+
+    def __getattr__(self, name):
+        return self.named_temporary_file.__getattr__(name)
+
+    def close(self):
+        return self.named_temporary_file.close()
+
+    #def __iter__(self):
+    #    for line in self.named_temporary_file:
+    #        yield line
+
+    def cleanup(self):
+        self.close()
+        try:
+            os.unlink(self.named_temporary_file.name)
+        except FileNotFoundError:
+            pass # cleaning up more than once is not an error
+
+
+def PortableNamedTemporaryFile(mode='w+b', suffix="",
+                       prefix=template, dir=None, delete=True):
+    """
+    Wrap tempfile.NamedTemporaryFile() with a portable behaviour that works on Windows, Linux and Mac
+    See https://docs.python.org/3/library/tempfile.html for full documentation.
+    The difference is that if you specify delete=True, the temporary file will be deleted when the returned
+    object is destroyed rather than when the file is closed. On windows, it is not possible to reopen the
+    file while the original handle is still open, so this function makes temporary files work across OS's.
+    """
+    if not delete:
+        return NamedTemporaryFile(mode=mode, suffix=suffix,
+                                  prefix=prefix, delete=delete)
+    else:
+        named_temporary_file = NamedTemporaryFile(mode=mode, suffix=suffix,
+                                                  prefix=prefix, delete=False)
+        return _PortableNamedTemporaryFileWrapper(named_temporary_file=named_temporary_file)

--- a/test/run.py
+++ b/test/run.py
@@ -16,6 +16,7 @@ from test_crj_g2p import TestSouthEastCreeG2P
 
 ## Other tests
 from test_tokenize_xml import TestTokenizer
+from test_temp_file import TestTempFile
 
 
 loader = TestLoader()
@@ -37,7 +38,7 @@ lang_tests = [
 
 other_tests = [
     loader.loadTestsFromTestCase(test)
-    for test in [TestTokenizer]
+    for test in [TestTokenizer, TestTempFile]
 ]
 
 def run_tests(suite):

--- a/test/test_force_align.py
+++ b/test/test_force_align.py
@@ -10,6 +10,7 @@ from lxml import etree
 from readalongs.log import LOGGER
 from readalongs.align import align_audio, create_input_xml, convert_to_xhtml
 from readalongs.text.util import save_xml, load_txt
+from readalongs.tempfile import PortableNamedTemporaryFile
 
 class TestForceAlignment(unittest.TestCase):
     LOGGER.setLevel('DEBUG')
@@ -54,7 +55,7 @@ class TestXHTML(unittest.TestCase):
         xml_path = os.path.join(self.data_dir, 'ap-git-converted-from-xml.xml')
         xml = etree.parse(xml_path).getroot()
         convert_to_xhtml(xml)
-        with tempfile.NamedTemporaryFile(suffix='.xml') as tf:
+        with PortableNamedTemporaryFile(suffix='.xml') as tf:
             save_xml(tf.name, xml)
             txt = load_txt(tf.name)
             self.maxDiff = None

--- a/test/test_temp_file.py
+++ b/test/test_temp_file.py
@@ -1,0 +1,75 @@
+"""
+Test PortableNamedTemporaryFile class
+"""
+
+import unittest
+import os
+import sys
+
+from readalongs.log import LOGGER
+from tempfile import NamedTemporaryFile
+from readalongs.tempfile import PortableNamedTemporaryFile
+
+class TestTempFile(unittest.TestCase):
+    def testBasicFile(self):
+        f = open("delme_test_temp_file", mode="w")
+        f.write("some text")
+        f.close()
+        os.unlink("delme_test_temp_file")
+
+    def testNTF(self):
+        tf = NamedTemporaryFile(prefix="testtempfile_testNTF_", delete=False, mode="w")
+        tf.write("Some text")
+        #LOGGER.debug("tf.name {}".format(tf.name))
+        tf.close()
+        readf = open(tf.name, mode="r")
+        text = readf.readline()
+        self.assertEqual(text, "Some text")
+        readf.close()
+        os.unlink(tf.name)
+
+    def testDeleteFalse(self):
+        tf = PortableNamedTemporaryFile(prefix="testtempfile_testDeleteFalse_", delete=False, mode="w")
+        tf.write("Some text")
+        tf.close()
+        #LOGGER.info(tf.name)
+        readf = open(tf.name, mode="r")
+        text = readf.readline()
+        readf.close()
+        self.assertEqual(text, "Some text")
+        os.unlink(tf.name)
+
+    def testTypicalUsage(self):
+        tf = PortableNamedTemporaryFile(prefix="testtempfile_testTypicalUsage_", delete=True, mode="w")
+        #LOGGER.info(tf.name)
+        tf.write("Some text")
+        tf.close()
+        #LOGGER.info(tf.name)
+        readf = open(tf.name, mode="r")
+        text = readf.readline()
+        readf.close()
+        self.assertEqual(text, "Some text")
+
+    def testUsingWith(self):
+        with PortableNamedTemporaryFile(prefix="testtempfile_testUsingWith_", delete=True, mode="w") as tf:
+            #LOGGER.info(tf.name)
+            tf.write("Some text")
+            tf.close()
+            #LOGGER.info(tf.name)
+            readf = open(tf.name, mode="r")
+            text = readf.readline()
+            readf.close()
+            self.assertEqual(text, "Some text")
+
+    def testSeek(self):
+        tf = PortableNamedTemporaryFile(prefix="testtempfile_testSeek_", delete=True, mode="w+")
+        tf.write("Some text")
+        tf.seek(0)
+        text = tf.readline()
+        self.assertEqual(text, "Some text")
+        tf.close()
+        os.unlink(tf.named_temporary_file.name)
+
+if __name__ == '__main__':
+    LOGGER.setLevel('DEBUG')
+    unittest.main()


### PR DESCRIPTION
Tested on Windows only so far. Please test on Mac or Linux. I don't want to merge this if it breaks things on other platforms, and currently I'm unable to run the tests on Linux due to VPN outages.

When running `python run.py dev` in `test/`, I get two failed tests and one error on Windows, which is an improvement over master, where I get 1 failure but three errors, two of which are fixed by this PR:

```
======================================================================
ERROR: test_conversions (test_context_g2p.TestG2P)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "c:\Users\joanise\RAS\ReadAlong-Studio\test\test_context_g2p.py", line 34, in test_conversions
    converter = make_g2p(test['in_lang'], test['out_lang'])
  File "c:\users\joanise\documents\readalong\g2p\g2p\__init__.py", line 27, in make_g2p
    raise(FileNotFoundError("No lang called {in_lang}."))
FileNotFoundError: No lang called {in_lang}.

======================================================================
FAIL: test_reduced_indices (test_context_g2p.TestG2P)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "c:\Users\joanise\RAS\ReadAlong-Studio\test\test_context_g2p.py", line 43, in test_reduced_indices
    (2, 2), (3, 5), (4, 8), (5, 9)])
AssertionError: Lists differ: [(2, 2), (3, 7), (4, 8), (5, 9)] != [(2, 2), (3, 5), (4, 8), (5, 9)]

First differing element 1:
(3, 7)
(3, 5)

- [(2, 2), (3, 7), (4, 8), (5, 9)]
?              ^

+ [(2, 2), (3, 5), (4, 8), (5, 9)]
?              ^


======================================================================
FAIL: testAlignText (test_force_align.TestForceAlignment)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "c:\Users\joanise\RAS\ReadAlong-Studio\test\test_force_align.py", line 48, in testAlignText
    self.assertEqual(xw.attrib['id'], w['id'])
AssertionError: 't0b0d0p0s0w0' != 's0w0'
- t0b0d0p0s0w0
+ s0w0


----------------------------------------------------------------------
Ran 15 tests in 5.228s

FAILED (failures=2, errors=1)
```